### PR TITLE
[Feat] 버튼 공통 컴포넌트

### DIFF
--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -5,7 +5,6 @@ export const buttonBaseStyle = css({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '100%',
   border: 'none',
   borderRadius: '12px',
   transition: 'all 0.2s ease-in-out',

--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -1,0 +1,34 @@
+import { css } from '@emotion/react';
+import { colors } from '@/styles/theme';
+
+export const buttonBaseStyle = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  border: 'none',
+  borderRadius: '12px',
+  transition: 'all 0.2s ease-in-out',
+
+  '&:hover': {
+    backgroundColor: colors.green_70,
+    color: colors.grayscale_0,
+  },
+
+  '&:disabled:not(:focus)': {
+    backgroundColor: colors.grayscale_20,
+    color: colors.grayscale_60,
+    cursor: 'not-allowed',
+  },
+});
+
+export const buttonVariantStyle = {
+  primary: css({
+    backgroundColor: colors.green_5,
+    color: colors.green_50,
+  }),
+  secondary: css({
+    backgroundColor: colors.green_50,
+    color: colors.grayscale_0,
+  }),
+};

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+import { ButtonHTMLAttributes } from 'react';
+import { buttonBaseStyle, buttonVariantStyle } from '@/components/Button/Button.style';
+import Text from '@/components/Text/Text';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+  padding?: string;
+  tag?: React.ComponentProps<typeof Text>['tag'];
+}
+
+const Button = ({
+  variant = 'primary',
+  padding = '1.7rem 14.45rem',
+  tag = 'lg-subtitle-semibold',
+  children,
+  ...props
+}: ButtonProps) => {
+  return (
+    <button css={[buttonBaseStyle, buttonVariantStyle[variant], css({ padding })]} {...props}>
+      <Text tag={tag}>{children}</Text>
+    </button>
+  );
+};
+
+export default Button;

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Button from '@/components/Button/Button';
+import { TextTag } from '@/types/textTyes';
+
+const textTagOptions: TextTag[] = [
+  'xxl-title-bold',
+  'xxl-title-semibold',
+  'xl-title-bold',
+  'xl-title-semibold',
+  'lg-subtitle-bold',
+  'lg-subtitle-semibold',
+  'lg-subtitle-medium',
+  'md1-text-bold',
+  'md1-text-semibold',
+  'md1-text-medium',
+  'md1-text-regular',
+  'md2-text-bold',
+  'md2-text-semibold',
+  'md2-text-medium',
+  'md2-text-regular',
+  'sm-text-semibold',
+  'sm-text-medium',
+  'sm-text-regular',
+  'xs-text-medium',
+  'xs-text-regular',
+  'xs-text-light',
+];
+
+const meta: Meta<typeof Button> = {
+  title: 'Common/Button',
+  component: Button,
+  argTypes: {
+    variant: {
+      control: { type: 'radio' },
+      options: ['primary', 'secondary'],
+      description: '버튼 스타일을 선택합니다.',
+    },
+    padding: {
+      control: { type: 'text' },
+      description: '버튼의 패딩을 설정합니다.',
+    },
+    tag: {
+      control: { type: 'select' },
+      options: textTagOptions,
+      description: 'Text 컴포넌트의 스타일을 선택합니다.',
+    },
+    children: {
+      control: 'text',
+      description: '버튼 내부의 텍스트입니다.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: '버튼을 비활성화합니다.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+    padding: '1.7rem 14.45rem',
+    tag: 'lg-subtitle-semibold',
+    children: 'Primary Button',
+    disabled: false,
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+    padding: '1.7rem 14.45rem',
+    tag: 'lg-subtitle-semibold',
+    children: 'Secondary Button',
+    disabled: false,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    variant: 'primary',
+    padding: '1.7rem 14.45rem',
+    tag: 'lg-subtitle-semibold',
+    children: 'Disabled Button',
+    disabled: true,
+  },
+};

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,4 +1,4 @@
-const colors = {
+export const colors = {
   main: '#E60012',
 
   sub_PANTONE_3022C: '#009857',


### PR DESCRIPTION
## 이슈 넘버
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->
- close #9 
  

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

버튼 공통 컴포넌트 구현


## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
버튼 variant를 primary, secondary 두가지로 분리
hover, disabled 공통 스타일 적용

버튼의 크기, text 글자, text 스타일 이 다 달라서 props로 받아올 수 있게 하였습니다.
padding 값은 상하 / 좌우 값 넘겨주고
variant는 primary, secondary 중 하나
tag 는 텍스트 태그 중 해당하는 거 넘겨주면됩니다!

예시 코드
```tsx
<Button variant="primary" padding="1.7rem 3rem" tag="lg-subtitle-semibold">
  로그인
</Button>
```
요러게 쓰면 됩니둥!! 




## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
스토리북 링크 참고해주세요!!



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
